### PR TITLE
Fix extension-key in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 	},
 	"extra": {
 		"typo3/cms": {
-			"extension-key": "redirect-tab",
+			"extension-key": "redirect_tab",
 			"cms-package-dir": "{$vendor-dir}/typo3/cms",
 			"web-dir": ".Build/Web"
 		}


### PR DESCRIPTION
With the previous extension-key, the extension got installed to the incorrect path redirect-tab, instead of redirect_tab.