### PR TITLE
Fix typo in method call

### DIFF
--- a/Classes/Service/RedirectDemandService.php
+++ b/Classes/Service/RedirectDemandService.php
@@ -84,7 +84,7 @@ class RedirectDemandService
     {
         $pagination = [];
         if ($demand !== null) {
-            $count = $this->redirectRepository->countRedirectsByByDemand($demand);
+            $count = $this->redirectRepository->countRedirectsByDemand($demand);
             $numberOfPages = ceil($count / $demand->getLimit());
             $endRecord = $demand->getOffset() + $demand->getLimit();
             if ($endRecord > $count) {


### PR DESCRIPTION
## Summary
- fix typo in RedirectDemandService::preparePagination

## Testing
- `composer run-script ci:tests:unit` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440148537c832987efaa2ff4c86f53