### PR TITLE
Fix typo, namespace, and add test

### DIFF
--- a/Resources/Private/Partials/Backend/Pagination.html
+++ b/Resources/Private/Partials/Backend/Pagination.html
@@ -46,7 +46,7 @@
                         We remove the form + input of the pagination here, as this affects the close button in the page properties.
                     </f:comment>
                     <f:translate extensionName="fluid" key="widget.pagination.page" />
-                        <f:variable name="gotToPageUrl">
+                        <f:variable name="goToPageUrl">
                             <f:variable name="routeParameters"><ac:routeParameters recordUid="{recordUid}" page="987654322" /></f:variable>
                             <f:be.uri route="record_edit" parameters="{routeParameters}" />
                         </f:variable>

--- a/Tests/Functional/Service/RedirectDemandServiceTest.php
+++ b/Tests/Functional/Service/RedirectDemandServiceTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ayacoo\Tiktok\Tests\Functional\Service;
+namespace Ayacoo\RedirectTab\Tests\Functional\Service;
 
 use Ayacoo\RedirectTab\Service\RedirectDemandService;
 use PHPUnit\Framework\Attributes\Test;

--- a/Tests/Unit/Event/ModifyRedirectsEventTest.php
+++ b/Tests/Unit/Event/ModifyRedirectsEventTest.php
@@ -20,4 +20,14 @@ final class ModifyRedirectsEventTest extends UnitTestCase
 
         self::assertEquals($expected, $result);
     }
+
+    #[Test]
+    public function setRedirectsUpdatesRedirects(): void
+    {
+        $subject = new ModifyRedirectsEvent([]);
+
+        $subject->setRedirects(['foo']);
+
+        self::assertEquals(['foo'], $subject->getRedirects());
+    }
 }


### PR DESCRIPTION
## Summary
- fix `goToPageUrl` typo in pagination partial
- correct namespace in functional test
- add unit test for ModifyRedirectsEvent::setRedirects

## Testing
- `vendor/bin/phpunit -c Build/phpunit/UnitTests.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6843ffba20f483298bb5c54e2316275b